### PR TITLE
Fix error when using SkyReels I2V Hunyuan Model

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -296,7 +296,7 @@ def teacache_hunyuanvideo_forward(
             shape[i] = shape[i] // self.patch_size[i]
         img = img.reshape([img.shape[0]] + shape + [self.out_channels] + self.patch_size)
         img = img.permute(0, 4, 1, 5, 2, 6, 3, 7)
-        img = img.reshape(initial_shape)
+        img = img.reshape(initial_shape[0], self.out_channels, initial_shape[2], initial_shape[3], initial_shape[4])
         return img
 
 def teacache_ltxvmodel_forward(


### PR DESCRIPTION
The number of out channels on the SkyReels Image-to-Video Hunyuan model is 32, compared to the normal 16. This change is the same fix applied to ComfyUI directly.

See: https://github.com/comfyanonymous/ComfyUI/commit/acc152b674fd1c983acc6efd8aedbeb380660c0c#diff-828ff060ac292e5b8eff646d924ade3720f1500a17b42ebdc3034c193ed4b597